### PR TITLE
Set container level securityContext for Affinity assistant

### DIFF
--- a/docs/additional-configs.md
+++ b/docs/additional-configs.md
@@ -461,7 +461,8 @@ Out-of-the-box, Tekton Pipelines Controller is configured for relatively small-s
 
 To allow TaskRuns and PipelineRuns to run in namespaces with [restricted pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/),
 set the "set-security-context" feature flag to "true" in the [feature-flags configMap](#customizing-the-pipelines-controller-behavior). This configuration option applies a [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
-to any containers injected into TaskRuns by the Pipelines controller. This SecurityContext may not be supported in all Kubernetes implementations (for example, OpenShift).
+to any containers injected into TaskRuns by the Pipelines controller. If the [Affinity Assistants](affinityassistants.md) feature is enabled, the SecurityContext is also applied to those containers.
+This SecurityContext may not be supported in all Kubernetes implementations (for example, OpenShift).
 
 **Note**: running TaskRuns and PipelineRuns in the "tekton-pipelines" namespace is discouraged.
 

--- a/pkg/internal/affinityassistant/affinityassistant_types.go
+++ b/pkg/internal/affinityassistant/affinityassistant_types.go
@@ -54,3 +54,9 @@ func GetAffinityAssistantBehavior(ctx context.Context) (AffinityAssistantBehavio
 
 	return "", fmt.Errorf("unknown combination of disable-affinity-assistant: %v and coschedule: %v", disableAA, coschedule)
 }
+
+// ContainerConfig defines AffinityAssistant container configuration
+type ContainerConfig struct {
+	Image              string
+	SetSecurityContext bool
+}

--- a/pkg/pod/pod.go
+++ b/pkg/pod/pod.go
@@ -60,8 +60,8 @@ const (
 	// SpiffeCsiDriver is the CSI storage plugin needed for injection of SPIFFE workload api.
 	SpiffeCsiDriver = "csi.spiffe.io"
 
-	// osSelectorLabel is the label Kubernetes uses for OS-specific workloads (https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os)
-	osSelectorLabel = "kubernetes.io/os"
+	// OsSelectorLabel is the label Kubernetes uses for OS-specific workloads (https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-os)
+	OsSelectorLabel = "kubernetes.io/os"
 
 	// TerminationReasonTimeoutExceeded indicates a step execution timed out.
 	TerminationReasonTimeoutExceeded = "TimeoutExceeded"
@@ -132,10 +132,10 @@ var (
 	allowPrivilegeEscalation = false
 	runAsNonRoot             = true
 
-	// The following security contexts allow init containers to run in namespaces
+	// LinuxSecurityContext allow init containers to run in namespaces
 	// with "restricted" pod security admission
 	// See https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted
-	linuxSecurityContext = &corev1.SecurityContext{
+	LinuxSecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: &allowPrivilegeEscalation,
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
@@ -145,7 +145,7 @@ var (
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
-	windowsSecurityContext = &corev1.SecurityContext{
+	WindowsSecurityContext = &corev1.SecurityContext{
 		RunAsNonRoot: &runAsNonRoot,
 	}
 )
@@ -703,9 +703,9 @@ func entrypointInitContainer(image string, steps []v1.Step, setSecurityContext, 
 		command = append(command, StepName(s.Name, i))
 	}
 	volumeMounts := []corev1.VolumeMount{binMount, internalStepsMount}
-	securityContext := linuxSecurityContext
+	securityContext := LinuxSecurityContext
 	if windows {
-		securityContext = windowsSecurityContext
+		securityContext = WindowsSecurityContext
 	}
 
 	// Rewrite steps with entrypoint binary. Append the entrypoint init
@@ -775,9 +775,9 @@ func createResultsSidecar(taskSpec v1.TaskSpec, image string, setSecurityContext
 		Image:   image,
 		Command: command,
 	}
-	securityContext := linuxSecurityContext
+	securityContext := LinuxSecurityContext
 	if windows {
-		securityContext = windowsSecurityContext
+		securityContext = WindowsSecurityContext
 	}
 	if setSecurityContext {
 		sidecar.SecurityContext = securityContext
@@ -792,7 +792,7 @@ func usesWindows(tr *v1.TaskRun) bool {
 	if tr.Spec.PodTemplate == nil || tr.Spec.PodTemplate.NodeSelector == nil {
 		return false
 	}
-	osSelector := tr.Spec.PodTemplate.NodeSelector[osSelectorLabel]
+	osSelector := tr.Spec.PodTemplate.NodeSelector[OsSelectorLabel]
 	return osSelector == "windows"
 }
 

--- a/pkg/pod/pod_test.go
+++ b/pkg/pod/pod_test.go
@@ -2161,7 +2161,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
-					SecurityContext: linuxSecurityContext,
+					SecurityContext: LinuxSecurityContext,
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -2402,7 +2402,7 @@ _EOF_
 						{Name: "tekton-internal-bin", ReadOnly: true, MountPath: "/tekton/bin"},
 						{Name: "tekton-internal-run-0", ReadOnly: true, MountPath: "/tekton/run/0"},
 					}, implicitVolumeMounts...),
-					SecurityContext: linuxSecurityContext,
+					SecurityContext: LinuxSecurityContext,
 				}},
 				Volumes: append(implicitVolumes, binVolume, runVolume(0), downwardVolume, corev1.Volume{
 					Name:         "tekton-creds-init-home-0",
@@ -3420,7 +3420,7 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:      "/",
 			Command:         []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts:    []corev1.VolumeMount{binMount, internalStepsMount},
-			SecurityContext: linuxSecurityContext,
+			SecurityContext: LinuxSecurityContext,
 		},
 	}, {
 		name: "nothing-special-two-steps-windows",
@@ -3452,7 +3452,7 @@ func TestPrepareInitContainers(t *testing.T) {
 			WorkingDir:      "/",
 			Command:         []string{"/ko-app/entrypoint", "init", "/ko-app/entrypoint", entrypointBinary, "step-foo", "step-bar"},
 			VolumeMounts:    []corev1.VolumeMount{binMount, internalStepsMount},
-			SecurityContext: windowsSecurityContext,
+			SecurityContext: WindowsSecurityContext,
 		},
 	}}
 	for _, tc := range tcs {
@@ -3481,13 +3481,13 @@ func TestUsesWindows(t *testing.T) {
 	}, {
 		name: "uses linux",
 		taskRun: &v1.TaskRun{Spec: v1.TaskRunSpec{PodTemplate: &pod.Template{NodeSelector: map[string]string{
-			osSelectorLabel: "linux",
+			OsSelectorLabel: "linux",
 		}}}},
 		want: false,
 	}, {
 		name: "uses windows",
 		taskRun: &v1.TaskRun{Spec: v1.TaskRunSpec{PodTemplate: &pod.Template{NodeSelector: map[string]string{
-			osSelectorLabel: "windows",
+			OsSelectorLabel: "windows",
 		}}}},
 		want: true,
 	}}

--- a/pkg/pod/script.go
+++ b/pkg/pod/script.go
@@ -87,13 +87,13 @@ func convertScripts(shellImageLinux string, shellImageWin string, steps []v1.Ste
 	shellImage := shellImageLinux
 	shellCommand := "sh"
 	shellArg := "-c"
-	securityContext := linuxSecurityContext
+	securityContext := LinuxSecurityContext
 	// Set windows variants for Image, Command and Args
 	if requiresWindows {
 		shellImage = shellImageWin
 		shellCommand = "pwsh"
 		shellArg = "-Command"
-		securityContext = windowsSecurityContext
+		securityContext = WindowsSecurityContext
 	}
 
 	placeScriptsInit := corev1.Container{

--- a/pkg/pod/script_test.go
+++ b/pkg/pod/script_test.go
@@ -159,7 +159,7 @@ _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: linuxSecurityContext,
+		SecurityContext: LinuxSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -457,7 +457,7 @@ fi
 debug-fail-continue-heredoc-randomly-generated-6nl7g
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount, debugScriptsVolumeMount},
-		SecurityContext: linuxSecurityContext,
+		SecurityContext: LinuxSecurityContext,
 	}
 
 	want := []corev1.Container{{
@@ -555,7 +555,7 @@ _EOF_
 /tekton/bin/entrypoint decode-script "${scriptfile}"
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: linuxSecurityContext,
+		SecurityContext: LinuxSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -642,7 +642,7 @@ no-shebang
 "@ | Out-File -FilePath /tekton/scripts/script-3-mssqb.cmd
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: windowsSecurityContext,
+		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -725,7 +725,7 @@ sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-mssqb
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: windowsSecurityContext,
+		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image:        "step-1",
@@ -787,7 +787,7 @@ sidecar-1
 "@ | Out-File -FilePath /tekton/scripts/sidecar-script-0-9l9zj
 `},
 		VolumeMounts:    []corev1.VolumeMount{writeScriptsVolumeMount, binMount},
-		SecurityContext: windowsSecurityContext,
+		SecurityContext: WindowsSecurityContext,
 	}
 	want := []corev1.Container{{
 		Image: "step-1",

--- a/pkg/pod/workingdir_init.go
+++ b/pkg/pod/workingdir_init.go
@@ -60,9 +60,9 @@ func workingDirInit(workingdirinitImage string, stepContainers []corev1.Containe
 		// There are no workingDirs to initialize.
 		return nil
 	}
-	securityContext := linuxSecurityContext
+	securityContext := LinuxSecurityContext
 	if windows {
-		securityContext = windowsSecurityContext
+		securityContext = WindowsSecurityContext
 	}
 
 	c := &corev1.Container{

--- a/pkg/pod/workingdir_init_test.go
+++ b/pkg/pod/workingdir_init_test.go
@@ -90,7 +90,7 @@ func TestWorkingDirInit(t *testing.T) {
 			Args:            []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:      pipeline.WorkspaceDir,
 			VolumeMounts:    implicitVolumeMounts,
-			SecurityContext: linuxSecurityContext,
+			SecurityContext: LinuxSecurityContext,
 		},
 	}, {
 		desc: "workingDirs are unique and sorted, absolute dirs are ignored, uses windows",
@@ -144,7 +144,7 @@ func TestWorkingDirInit(t *testing.T) {
 			Args:            []string{"/workspace/bbb", "aaa", "zzz"},
 			WorkingDir:      pipeline.WorkspaceDir,
 			VolumeMounts:    implicitVolumeMounts,
-			SecurityContext: windowsSecurityContext,
+			SecurityContext: WindowsSecurityContext,
 		},
 	}} {
 		t.Run(c.desc, func(t *testing.T) {

--- a/pkg/reconciler/pipelinerun/affinity_assistant.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant.go
@@ -23,6 +23,8 @@ import (
 	"errors"
 	"fmt"
 
+	pipelinePod "github.com/tektoncd/pipeline/pkg/pod"
+
 	"github.com/tektoncd/pipeline/pkg/apis/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
@@ -139,7 +141,12 @@ func (c *Reconciler) createOrUpdateAffinityAssistant(ctx context.Context, affini
 		if err != nil {
 			return []error{err}
 		}
-		affinityAssistantStatefulSet := affinityAssistantStatefulSet(aaBehavior, affinityAssistantName, pr, claimTemplates, claimNames, c.Images.NopImage, cfg.Defaults.DefaultAAPodTemplate)
+		affinityAssistantContainerConfig := aa.ContainerConfig{
+			Image:              c.Images.NopImage,
+			SetSecurityContext: cfg.FeatureFlags.SetSecurityContext,
+		}
+
+		affinityAssistantStatefulSet := affinityAssistantStatefulSet(aaBehavior, affinityAssistantName, pr, claimTemplates, claimNames, affinityAssistantContainerConfig, cfg.Defaults.DefaultAAPodTemplate)
 		_, err = c.KubeClientSet.AppsV1().StatefulSets(pr.Namespace).Create(ctx, affinityAssistantStatefulSet, metav1.CreateOptions{})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to create StatefulSet %s: %w", affinityAssistantName, err))
@@ -281,7 +288,7 @@ func getStatefulSetLabels(pr *v1.PipelineRun, affinityAssistantName string) map[
 // with the given AffinityAssistantTemplate applied to the StatefulSet PodTemplateSpec.
 // The VolumeClaimTemplates and Volume of StatefulSet reference the PipelineRun WorkspaceBinding VolumeClaimTempalte and the PVCs respectively.
 // The PVs created by the StatefulSet are scheduled to the same availability zone which avoids PV scheduling conflict.
-func affinityAssistantStatefulSet(aaBehavior aa.AffinityAssistantBehavior, name string, pr *v1.PipelineRun, claimTemplates []corev1.PersistentVolumeClaim, claimNames []string, affinityAssistantImage string, defaultAATpl *pod.AffinityAssistantTemplate) *appsv1.StatefulSet {
+func affinityAssistantStatefulSet(aaBehavior aa.AffinityAssistantBehavior, name string, pr *v1.PipelineRun, claimTemplates []corev1.PersistentVolumeClaim, claimNames []string, containerConfig aa.ContainerConfig, defaultAATpl *pod.AffinityAssistantTemplate) *appsv1.StatefulSet {
 	// We want a singleton pod
 	replicas := int32(1)
 
@@ -296,9 +303,18 @@ func affinityAssistantStatefulSet(aaBehavior aa.AffinityAssistantBehavior, name 
 		mounts = append(mounts, corev1.VolumeMount{Name: claimTemplate.Name, MountPath: claimTemplate.Name})
 	}
 
+	securityContext := &corev1.SecurityContext{}
+	if containerConfig.SetSecurityContext {
+		securityContext = pipelinePod.LinuxSecurityContext
+
+		if tpl.NodeSelector[pipelinePod.OsSelectorLabel] == "windows" {
+			securityContext = pipelinePod.WindowsSecurityContext
+		}
+	}
+
 	containers := []corev1.Container{{
 		Name:  "affinity-assistant",
-		Image: affinityAssistantImage,
+		Image: containerConfig.Image,
 		Args:  []string{"tekton_run_indefinitely"},
 
 		// Set requests == limits to get QoS class _Guaranteed_.
@@ -314,7 +330,8 @@ func affinityAssistantStatefulSet(aaBehavior aa.AffinityAssistantBehavior, name 
 				"memory": resource.MustParse("100Mi"),
 			},
 		},
-		VolumeMounts: mounts,
+		SecurityContext: securityContext,
+		VolumeMounts:    mounts,
 	}}
 
 	var volumes []corev1.Volume

--- a/pkg/reconciler/pipelinerun/affinity_assistant_test.go
+++ b/pkg/reconciler/pipelinerun/affinity_assistant_test.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"testing"
 
+	pipelinePod "github.com/tektoncd/pipeline/pkg/pod"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/tektoncd/pipeline/pkg/apis/config"
@@ -50,8 +52,14 @@ import (
 )
 
 var (
-	podSpecFilter         cmp.Option = cmpopts.IgnoreFields(corev1.PodSpec{}, "Containers", "Affinity")
+	podSpecFilter         cmp.Option = cmpopts.IgnoreFields(corev1.PodSpec{}, "Affinity")
 	podTemplateSpecFilter cmp.Option = cmpopts.IgnoreFields(corev1.PodTemplateSpec{}, "ObjectMeta")
+	podContainerFilter    cmp.Option = cmpopts.IgnoreFields(corev1.Container{}, "Resources", "Args", "VolumeMounts")
+
+	containerConfigWithoutSecurityContext = aa.ContainerConfig{
+		Image:              "nginx",
+		SetSecurityContext: false,
+	}
 )
 
 var (
@@ -117,14 +125,31 @@ var testPRWithEmptyDir = &v1.PipelineRun{
 	},
 }
 
+var testPRWithWindowsOs = &v1.PipelineRun{
+	ObjectMeta: metav1.ObjectMeta{Name: "pipelinerun-with-windows"},
+	Spec: v1.PipelineRunSpec{
+		TaskRunTemplate: v1.PipelineTaskRunTemplate{
+			PodTemplate: &pod.PodTemplate{
+				NodeSelector: map[string]string{pipelinePod.OsSelectorLabel: "windows"},
+			},
+		},
+		Workspaces: []v1.WorkspaceBinding{{
+			Name:     "EmptyDir Workspace",
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		}},
+	},
+}
+
 // TestCreateOrUpdateAffinityAssistantsAndPVCsPerPipelineRun tests to create and delete Affinity Assistants and PVCs
 // per pipelinerun for a given PipelineRun
 func TestCreateOrUpdateAffinityAssistantsAndPVCsPerPipelineRun(t *testing.T) {
 	replicas := int32(1)
+
 	tests := []struct {
 		name                  string
 		pr                    *v1.PipelineRun
 		expectStatefulSetSpec *appsv1.StatefulSetSpec
+		featureFlags          map[string]string
 	}{{
 		name: "PersistentVolumeClaim Workspace type",
 		pr:   testPRWithPVC,
@@ -139,6 +164,10 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerPipelineRun(t *testing.T) {
 			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
 					Volumes: []corev1.Volume{{
 						Name: "workspace-0",
 						VolumeSource: corev1.VolumeSource{
@@ -158,6 +187,14 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerPipelineRun(t *testing.T) {
 					pipeline.PipelineRunLabelKey: testPRWithVolumeClaimTemplate.Name,
 					workspace.LabelInstance:      "affinity-assistant-426b306c50",
 					workspace.LabelComponent:     workspace.ComponentNameAffinityAssistant,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
 				},
 			},
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
@@ -181,6 +218,10 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerPipelineRun(t *testing.T) {
 			}},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
 					Volumes: []corev1.Volume{{
 						Name: "workspace-0",
 						VolumeSource: corev1.VolumeSource{
@@ -202,17 +243,79 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerPipelineRun(t *testing.T) {
 					workspace.LabelComponent:     workspace.ComponentNameAffinityAssistant,
 				},
 			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
+				},
+			},
+		},
+	}, {
+		name: "securityContext feature enabled and os is Windows",
+		pr:   testPRWithWindowsOs,
+		featureFlags: map[string]string{
+			"set-security-context": "true",
+		},
+		expectStatefulSetSpec: &appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					pipeline.PipelineRunLabelKey: testPRWithWindowsOs.Name,
+					workspace.LabelInstance:      "affinity-assistant-01cecfbdec",
+					workspace.LabelComponent:     workspace.ComponentNameAffinityAssistant,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					NodeSelector: map[string]string{pipelinePod.OsSelectorLabel: "windows"},
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: pipelinePod.WindowsSecurityContext,
+					}},
+				},
+			},
+		},
+	}, {
+		name: "securityContext feature enabled and os is Linux",
+		pr:   testPRWithEmptyDir,
+		featureFlags: map[string]string{
+			"set-security-context": "true",
+		},
+		expectStatefulSetSpec: &appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					pipeline.PipelineRunLabelKey: testPRWithEmptyDir.Name,
+					workspace.LabelInstance:      "affinity-assistant-c655a0c8a2",
+					workspace.LabelComponent:     workspace.ComponentNameAffinityAssistant,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: pipelinePod.LinuxSecurityContext,
+					}},
+				},
+			},
 		},
 	}}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			configMap := map[string]string{
+			featureFlags := map[string]string{
 				"disable-affinity-assistant": "true",
 				"coschedule":                 "pipelineruns",
 			}
+
+			for k, v := range tc.featureFlags {
+				featureFlags[k] = v
+			}
+
 			kubeClientSet := fakek8s.NewSimpleClientset()
-			ctx := cfgtesting.SetFeatureFlags(context.Background(), t, configMap)
+			ctx := cfgtesting.SetFeatureFlags(context.Background(), t, featureFlags)
 			c := Reconciler{
 				KubeClientSet: kubeClientSet,
 				pvcHandler:    volumeclaim.NewPVCHandler(kubeClientSet, zap.NewExample().Sugar()),
@@ -264,6 +367,10 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerWorkspaceOrDisabled(t *testin
 			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
 					Volumes: []corev1.Volume{{
 						Name: "workspace-0",
 						VolumeSource: corev1.VolumeSource{
@@ -289,6 +396,10 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerWorkspaceOrDisabled(t *testin
 			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
 					Volumes: []corev1.Volume{{
 						Name: "workspace-0",
 						VolumeSource: corev1.VolumeSource{
@@ -319,6 +430,10 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerWorkspaceOrDisabled(t *testin
 			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
 					Volumes: []corev1.Volume{{
 						Name: "workspace-0",
 						VolumeSource: corev1.VolumeSource{
@@ -338,6 +453,10 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCsPerWorkspaceOrDisabled(t *testin
 			},
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:            "affinity-assistant",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
 					Volumes: []corev1.Volume{{
 						Name: "workspace-0",
 						VolumeSource: corev1.VolumeSource{
@@ -475,7 +594,7 @@ func TestCreateOrUpdateAffinityAssistantsAndPVCs_Failure(t *testing.T) {
 }
 
 // TestCreateOrUpdateAffinityAssistantWhenNodeIsCordoned tests an existing Affinity Assistant can identify the node failure and
-// can migrate the affinity assistant pod to a healthy node so that the existing pipelineRun runs to competition
+// can migrate the affinity assistant pod to a healthy node so that the existing pipelineRun runs to compleition
 func TestCreateOrUpdateAffinityAssistantWhenNodeIsCordoned(t *testing.T) {
 	expectedAffinityAssistantName := GetAffinityAssistantName(workspacePVCName, testPRWithPVC.Name)
 
@@ -621,7 +740,7 @@ func TestPipelineRunPodTemplatesArePropagatedToAffinityAssistant(t *testing.T) {
 		},
 	}
 
-	stsWithTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, "nginx", nil)
+	stsWithTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, nil)
 
 	if len(stsWithTolerationsAndNodeSelector.Spec.Template.Spec.Tolerations) != 1 {
 		t.Errorf("expected Tolerations in the StatefulSet")
@@ -659,7 +778,7 @@ func TestDefaultPodTemplatesArePropagatedToAffinityAssistant(t *testing.T) {
 		}},
 	}
 
-	stsWithTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, "nginx", defaultTpl)
+	stsWithTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, defaultTpl)
 
 	if len(stsWithTolerationsAndNodeSelector.Spec.Template.Spec.Tolerations) != 1 {
 		t.Errorf("expected Tolerations in the StatefulSet")
@@ -707,7 +826,7 @@ func TestMergedPodTemplatesArePropagatedToAffinityAssistant(t *testing.T) {
 		}},
 	}
 
-	stsWithTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, "nginx", defaultTpl)
+	stsWithTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, defaultTpl)
 
 	if len(stsWithTolerationsAndNodeSelector.Spec.Template.Spec.Tolerations) != 1 {
 		t.Errorf("expected Tolerations from spec in the StatefulSet")
@@ -746,7 +865,7 @@ func TestOnlySelectPodTemplateFieldsArePropagatedToAffinityAssistant(t *testing.
 		},
 	}
 
-	stsWithTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, "nginx", nil)
+	stsWithTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, nil)
 
 	if len(stsWithTolerationsAndNodeSelector.Spec.Template.Spec.Tolerations) != 1 {
 		t.Errorf("expected Tolerations from spec in the StatefulSet")
@@ -766,7 +885,7 @@ func TestThatTheAffinityAssistantIsWithoutNodeSelectorAndTolerations(t *testing.
 		Spec: v1.PipelineRunSpec{},
 	}
 
-	stsWithoutTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithoutCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, "nginx", nil)
+	stsWithoutTolerationsAndNodeSelector := affinityAssistantStatefulSet(aa.AffinityAssistantPerWorkspace, "test-assistant", prWithoutCustomPodTemplate, []corev1.PersistentVolumeClaim{}, []string{}, containerConfigWithoutSecurityContext, nil)
 
 	if len(stsWithoutTolerationsAndNodeSelector.Spec.Template.Spec.Tolerations) != 0 {
 		t.Errorf("unexpected Tolerations in the StatefulSet")
@@ -1244,7 +1363,7 @@ func validateStatefulSetSpec(t *testing.T, ctx context.Context, c Reconciler, ex
 		if err != nil {
 			t.Fatalf("unexpected error when retrieving StatefulSet: %v", err)
 		}
-		if d := cmp.Diff(expectStatefulSetSpec, &aa.Spec, podSpecFilter, podTemplateSpecFilter); d != "" {
+		if d := cmp.Diff(expectStatefulSetSpec, &aa.Spec, podSpecFilter, podTemplateSpecFilter, podContainerFilter); d != "" {
 			t.Errorf("StatefulSetSpec diff: %s", diff.PrintWantGot(d))
 		}
 	} else if !apierrors.IsNotFound(err) {


### PR DESCRIPTION
Solves https://github.com/tektoncd/pipeline/issues/8181

# Changes

Added container securityContext for affinity assistant when feature flag `set-security-context` is set to true. 
Implemented for both windows and linux OS. 

# Submitter Checklist

As the author of this PR, please check off the items in this checklist:

- [x] Has [Docs](https://github.com/tektoncd/community/blob/main/standards.md#docs) if any changes are user facing, including updates to minimum requirements e.g. Kubernetes version bumps
- [x] Has [Tests](https://github.com/tektoncd/community/blob/main/standards.md#tests) included if any functionality added or changed
- [x] [pre-commit](https://github.com/tektoncd/pipeline/blob/main/DEVELOPMENT.md#install-tools) Passed
- [x] Follows the [commit message standard](https://github.com/tektoncd/community/blob/main/standards.md#commits)
- [x] Meets the [Tekton contributor standards](https://github.com/tektoncd/community/blob/main/standards.md) (including functionality, content, code)
- [ ] Has a kind label. You can add one by adding a comment on this PR that contains `/kind <type>`. Valid types are bug, cleanup, design, documentation, feature, flake, misc, question, tep
- [x] Release notes block below has been updated with any user facing changes (API changes, bug fixes, changes requiring upgrade notices or deprecation warnings). See some examples of [good release notes](https://github.com/tektoncd/community/blob/main/standards.md#good-release-notes).
- [x] Release notes contains the string "action required" if the change requires additional action from users switching to the new release

# Release Notes

```release-note
Affinity Assistant containers will now have a securityContext when feature flag `set-security-context` is enabled in ConfigMap `feature-flags`.
```
